### PR TITLE
Replace assert() calls with overridable OLGA_ASSERT() macro

### DIFF
--- a/include/olga_scheduler/olga_scheduler.h
+++ b/include/olga_scheduler/olga_scheduler.h
@@ -19,9 +19,17 @@
 
 #pragma once
 
+#ifndef OLGA_ASSERT
+#include <assert.h>
+#define OLGA_ASSERT(x) assert(x)
+#endif
+
+#ifndef CAVL_ASSERT
+#define CAVL_ASSERT(x) OLGA_ASSERT(x)
+#endif
+
 #include <cavl2.h> // Add to your include paths: https://github.com/pavel-kirienko/cavl
 
-#include <assert.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -79,8 +87,8 @@ typedef struct olga_spin_result_t
 /// The time units can be arbitrary.
 static inline void olga_init(olga_t* const self, void* const user, int64_t (*const now)(olga_t* sched))
 {
-    assert(self != NULL);
-    assert(now != NULL);
+    OLGA_ASSERT(self != NULL);
+    OLGA_ASSERT(now != NULL);
     self->events     = NULL;
     self->next_seqno = 0U;
     self->now        = now;
@@ -115,9 +123,9 @@ static inline void olga_defer(olga_t* const        self,
                               const olga_handler_t handler,
                               olga_event_t* const  out_event)
 {
-    assert(self != NULL);
-    assert(handler != NULL);
-    assert(out_event != NULL);
+    OLGA_ASSERT(self != NULL);
+    OLGA_ASSERT(handler != NULL);
+    OLGA_ASSERT(out_event != NULL);
     (void)cavl2_remove_if(&self->events, &out_event->base);
     out_event->deadline = deadline;
     out_event->seqno    = self->next_seqno++;
@@ -131,8 +139,8 @@ static inline void olga_defer(olga_t* const        self,
 /// The complexity is logarithmic in the number of pending events.
 static inline void olga_cancel(olga_t* const self, olga_event_t* const event)
 {
-    assert(self != NULL);
-    assert(event != NULL);
+    OLGA_ASSERT(self != NULL);
+    OLGA_ASSERT(event != NULL);
     (void)cavl2_remove_if(&self->events, &event->base);
     event->deadline = INT64_MIN;
 }
@@ -140,8 +148,8 @@ static inline void olga_cancel(olga_t* const self, olga_event_t* const event)
 /// True if the event is currently pending in the scheduler.
 static inline bool olga_is_pending(const olga_t* const self, const olga_event_t* const event)
 {
-    assert(self != NULL);
-    assert(event != NULL);
+    OLGA_ASSERT(self != NULL);
+    OLGA_ASSERT(event != NULL);
     return cavl2_is_inserted(self->events, &event->base);
 }
 
@@ -151,7 +159,7 @@ static inline bool olga_is_pending(const olga_t* const self, const olga_event_t*
 /// This method should be invoked regularly to pump the event loop.
 static inline olga_spin_result_t olga_spin(olga_t* const self)
 {
-    assert(self != NULL);
+    OLGA_ASSERT(self != NULL);
     olga_spin_result_t out = { .next_deadline = INT64_MAX, .worst_lateness = 0, .now = INT64_MIN };
     for (;;) { // GCOVR_EXCL_LINE
         olga_event_t* const event = (olga_event_t*)cavl2_min(self->events);

--- a/include/olga_scheduler/olga_scheduler.h
+++ b/include/olga_scheduler/olga_scheduler.h
@@ -24,8 +24,8 @@
 #define OLGA_ASSERT(x) assert(x)
 #endif
 
-#ifndef CAVL_ASSERT
-#define CAVL_ASSERT(x) OLGA_ASSERT(x)
+#ifndef CAVL2_ASSERT
+#define CAVL2_ASSERT(x) OLGA_ASSERT(x)
 #endif
 
 #include <cavl2.h> // Add to your include paths: https://github.com/pavel-kirienko/cavl

--- a/include/olga_scheduler/olga_scheduler.hpp
+++ b/include/olga_scheduler/olga_scheduler.hpp
@@ -17,9 +17,17 @@
 
 #pragma once
 
+#ifndef OLGA_ASSERT
+#include <assert.h>
+#define OLGA_ASSERT(x) assert(x)
+#endif
+
+#ifndef CAVL_ASSERT
+#define CAVL_ASSERT(x) OLGA_ASSERT(x)
+#endif
+
 #include <cavl.hpp>
 
-#include <cassert>
 #include <chrono>
 #include <concepts>
 #include <optional>
@@ -113,9 +121,9 @@ class Event : private cavl::Node<Event<TimePoint>>
     virtual ~Event()
     {
         cancel();
-        assert(deadline_ == TimePoint::min());
-        assert((this->getChildNode(false) == nullptr) && (this->getChildNode(true) == nullptr) &&
-               (this->getParentNode() == nullptr));
+        OLGA_ASSERT(deadline_ == TimePoint::min());
+        OLGA_ASSERT((this->getChildNode(false) == nullptr) && (this->getChildNode(true) == nullptr) &&
+                    (this->getParentNode() == nullptr));
     }
 
     Event(Event&& other) noexcept
@@ -138,8 +146,8 @@ class Event : private cavl::Node<Event<TimePoint>>
               return (dead >= other.deadline_) ? +1 : -1;
           },
           [this] { return this; });
-        assert(std::get<0>(ptr_existing) == this);
-        assert(!std::get<1>(ptr_existing));
+        OLGA_ASSERT(std::get<0>(ptr_existing) == this);
+        OLGA_ASSERT(!std::get<1>(ptr_existing));
         (void)ptr_existing;
     }
 
@@ -208,7 +216,7 @@ class EventLoop final
     ~EventLoop()
     {
         // If this fails, it means that some events have outlived the event loop, which is not permitted.
-        assert(isEmpty());
+        OLGA_ASSERT(isEmpty());
     }
 
     /// The provided handler will be invoked with the specified interval starting from (now + period);
@@ -239,7 +247,7 @@ class EventLoop final
             const duration period_;
             const Fun      handler_;
         };
-        assert(period > duration::zero());
+        OLGA_ASSERT(period > duration::zero());
         return Impl{ *this, period, std::forward<Fun>(handler) };
     }
 
@@ -274,7 +282,7 @@ class EventLoop final
             const duration min_period_;
             const Fun      handler_;
         };
-        assert(min_period > duration::zero());
+        OLGA_ASSERT(min_period > duration::zero());
         return Impl{ *this, min_period, std::forward<Fun>(handler) };
     }
 
@@ -345,8 +353,8 @@ class EventLoop final
             result.worst_lateness = std::max(result.worst_lateness, result.approx_now - deadline);
         }
 
-        assert(result.approx_now > time_point::min());
-        assert(result.worst_lateness >= duration::zero());
+        OLGA_ASSERT(result.approx_now > time_point::min());
+        OLGA_ASSERT(result.worst_lateness >= duration::zero());
         return result;
     }
 

--- a/include/olga_scheduler/olga_scheduler.hpp
+++ b/include/olga_scheduler/olga_scheduler.hpp
@@ -18,7 +18,7 @@
 #pragma once
 
 #ifndef OLGA_ASSERT
-#include <assert.h>
+#include <cassert>
 #define OLGA_ASSERT(x) assert(x)
 #endif
 


### PR DESCRIPTION
Especially useful for embedded to not have to link `printf`